### PR TITLE
Move tests to the composer autoload-dev section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,11 @@
     },
     "autoload": {
         "psr-4": {
-            "sclable\\xmlLint\\": "src/php/",
+            "sclable\\xmlLint\\": "src/php/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "sclable\\xmlLint\\tests\\": "tests/"
         }
     }


### PR DESCRIPTION
Classes needed to run the test suite are not included in the main autoload rules to avoid polluting the autoloader when used as a dependency.

See [Composer schema for autoload-dev](https://getcomposer.org/doc/04-schema.md#autoload-dev)