### PR TITLE
Fix coding standards violation in functional tests

### DIFF
--- a/tests/functional/contexts/FeatureContext.php
+++ b/tests/functional/contexts/FeatureContext.php
@@ -38,7 +38,6 @@ class FeatureContext implements Context, SnippetAcceptingContext
         $command = $this->application->find('lint');
 
         $this->commandTester = new CommandTester($command);
-
     }
 
     /**


### PR DESCRIPTION
Removed empty line before closing brace to fix Code Sniff violation.