### PR TITLE
 Add support for PHP 7.3+ and 8.0+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "bin": ["bin/xmllint"],
     "require": {
-        "php": "7.3.*|7.4.*|8.0.*",
+        "php": "^7.3 || ^8.0",
         "symfony/console": "3.4.*|4.4.*|5.*",
         "symfony/finder": "3.4.*|4.4.*|5.*",
         "ext-libxml": "*",


### PR DESCRIPTION
We would like to fully upgrade our project to PHP 8.0 and have been running this for a couple of months without issues